### PR TITLE
Fixing librosa compatibility issue and UTF-8 issue

### DIFF
--- a/meldataset.py
+++ b/meldataset.py
@@ -115,7 +115,7 @@ class FilePathDataset(torch.utils.data.Dataset):
         if wave.shape[-1] == 2:
             wave = wave[:, 0].squeeze()
         if sr != 24000:
-            wave = librosa.resample(wave, sr, 24000)
+            wave = librosa.resample(wave, orig_sr=sr, target_sr=24000)
             print(wave_path, sr)
             
         wave = np.concatenate([np.zeros([5000]), wave, np.zeros([5000])], axis=0)

--- a/utils.py
+++ b/utils.py
@@ -31,9 +31,9 @@ def get_data_path_list(train_path=None, val_path=None):
     if val_path is None:
         val_path = "Data/val_list.txt"
 
-    with open(train_path, 'r') as f:
+    with open(train_path, 'r', encoding='utf-8', errors='ignore') as f:
         train_list = f.readlines()
-    with open(val_path, 'r') as f:
+    with open(val_path, 'r', encoding='utf-8', errors='ignore') as f:
         val_list = f.readlines()
 
     return train_list, val_list


### PR DESCRIPTION
When running train_first.py with librosa 0.10 I got error about resample call:
```
Original Traceback (most recent call last):
  File "C:\Python310\lib\site-packages\torch\utils\data\_utils\worker.py", line 308, in _worker_loop
    data = fetcher.fetch(index)
  File "C:\Python310\lib\site-packages\torch\utils\data\_utils\fetch.py", line 51, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "C:\Python310\lib\site-packages\torch\utils\data\_utils\fetch.py", line 51, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "E:\Work\StyleTTS\meldataset.py", line 101, in __getitem__
    wave, text_tensor, speaker_id = self._load_tensor(data)
  File "E:\Work\StyleTTS\meldataset.py", line 119, in _load_tensor
    wave = librosa.resample(wave, sr, 24000)
TypeError: resample() takes 1 positional argument but 3 were given
```
Fixing it with the line 'wave = librosa.resample(wave, orig_sr=sr, target_sr=24000)'

Also fixing an issue of reading the UTF-8 file without specifying the encoding which led to an error about unknown character on Windows.