### PR TITLE
continue correct number of epoch from pretrained

### DIFF
--- a/train_first.py
+++ b/train_first.py
@@ -118,6 +118,7 @@ def main(config_path):
     if config.get('pretrained_model', '') != '':
         model, optimizer, start_epoch, iters = load_checkpoint(model,  optimizer, config['pretrained_model'],
                                     load_only_params=config.get('load_only_params', True))
+        start_epoch = start_epoch + 1
     else:
         start_epoch = 0
         iters = 0

--- a/train_second.py
+++ b/train_second.py
@@ -132,6 +132,7 @@ def main(config_path):
     if config.get('pretrained_model', '') != '' and config.get('second_stage_load_pretrained', False):
         model, optimizer, start_epoch, iters = load_checkpoint(model,  optimizer, config['pretrained_model'],
                                     load_only_params=config.get('load_only_params', True))
+        start_epoch = start_epoch + 1
     else:
         start_epoch = 0
         iters = 0


### PR DESCRIPTION
Continue correct number of epoch from pre-trained model.
For example if pre-trained model saved as 6 epoch we will be continue train 7 epoch.
